### PR TITLE
Fix scopes handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Scopes handling. The scope passed from client requests was ignored, and the
+  resulting access token scope was always the default one. This has been fixed,
+  and Doorkeeper's `enforce_configured_scopes` setting is also honored
+  (refer to https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes).
 
 ## [0.2.0] - 2021-01-08
 ### Added

--- a/app/controllers/doorkeeper/device_authorization_grant/device_codes_controller.rb
+++ b/app/controllers/doorkeeper/device_authorization_grant/device_codes_controller.rb
@@ -9,7 +9,7 @@ module Doorkeeper
       def create
         headers.merge!(authorize_response.headers)
         render(json: authorize_response.body, status: authorize_response.status)
-      rescue Errors::DoorkeeperError => e
+      rescue Doorkeeper::Errors::DoorkeeperError => e
         handle_token_exception(e)
       end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,11 @@
 en:
+  activerecord:
+    errors:
+      models:
+        doorkeeper/device_authorization_grant/device_grant:
+          attributes:
+            scopes:
+              not_match_configured: "doesn't match configured on the server."
   doorkeeper:
     device_authorization_grant:
       device_authorizations:

--- a/lib/doorkeeper/device_authorization_grant/oauth/device_authorization_request.rb
+++ b/lib/doorkeeper/device_authorization_grant/oauth/device_authorization_request.rb
@@ -18,11 +18,13 @@ module Doorkeeper
         # @param server
         # @param client
         # @param host_name [String]
-        def initialize(server, client, host_name)
+        # @param parameters [Hash]
+        def initialize(server, client, host_name, parameters = {}) # rubocop:disable Style/OptionHash
           super()
           @server = server
           @client = client
           @host_name = host_name
+          @original_scopes = parameters[:scope]
         end
 
         # @return [DeviceAuthorizationResponse, Doorkeeper::OAuth::ErrorResponse]

--- a/lib/doorkeeper/device_authorization_grant/request/device_authorization.rb
+++ b/lib/doorkeeper/device_authorization_grant/request/device_authorization.rb
@@ -7,14 +7,15 @@ module Doorkeeper
       #
       # @see https://tools.ietf.org/html/rfc8628#section-3.1 RFC 8628, sect. 3.1
       class DeviceAuthorization < ::Doorkeeper::Request::Strategy
-        delegate :client, to: :server
+        delegate :client, :parameters, to: :server
 
         # @return [OAuth::DeviceAuthorizationRequest]
         def request
           @request ||= OAuth::DeviceAuthorizationRequest.new(
             Doorkeeper.configuration,
             client,
-            host_name
+            host_name,
+            parameters
           )
         end
 


### PR DESCRIPTION
The scope passed from client requests was ignored, and the resulting access token scope was always the default one. This has been fixed, and Doorkeeper's `enforce_configured_scopes` setting is also honored (refer to https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes).