### PR TITLE
Return device_code in plaintext, rather than hashed for DeviceAuthorizationResponse

### DIFF
--- a/lib/doorkeeper/device_authorization_grant/oauth/device_authorization_response.rb
+++ b/lib/doorkeeper/device_authorization_grant/oauth/device_authorization_response.rb
@@ -29,7 +29,7 @@ module Doorkeeper
         # @return [Hash]
         def body
           {
-            'device_code' => device_grant.device_code,
+            'device_code' => device_grant.plaintext_device_code,
             'user_code' => device_grant.user_code,
             'verification_uri' => verification_uri,
             'verification_uri_complete' => verification_uri_complete,

--- a/test/lib/oauth/device_authorization_response_test.rb
+++ b/test/lib/oauth/device_authorization_response_test.rb
@@ -53,7 +53,7 @@ module Doorkeeper
         end
 
         test '#body includes the device code' do
-          assert_equal @device_grant.device_code, @response.body['device_code']
+          assert_equal @device_grant.plaintext_device_code, @response.body['device_code']
         end
 
         test '#body includes the user code' do


### PR DESCRIPTION
This fixes a bug when using the `hash_token_secrets` config with no fallback in Doorkeeper. Essentially, this gem is already hashing and storing a value at 

https://github.com/iheanyi/doorkeeper-device_authorization_grant/blob/d5ada2a019a77d734d53e907b705b1e852dc0a73/lib/doorkeeper/device_authorization_grant/orm/active_record/device_grant_mixin.rb#L128-L129.

But then, a bug exists here. 

https://github.com/iheanyi/doorkeeper-device_authorization_grant/blob/d5ada2a019a77d734d53e907b705b1e852dc0a73/lib/doorkeeper/device_authorization_grant/orm/active_record/device_grant_mixin.rb#L58-L63

When looking up the following code, it will attempt to look up by a hash of the hashed value, making it impossible to lookup the secret. By passing this plaintext value back, we'll be able to look this up. Also, this function will now operate as it is expected with the inputted value.

This is similar to what Doorkeeper is doing for their token response [here](https://github.com/doorkeeper-gem/doorkeeper/blob/main/lib/doorkeeper/oauth/token_response.rb#L14).

Tests pass locally:

```zsh
❯ bundle exec rails test
Run options: --seed 12950

# Running:

.................................................................

Finished in 0.659060s, 98.6253 runs/s, 189.6641 assertions/s.
65 runs, 125 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Minitest to /Users/iheanyi/development/doorkeeper-device_authorization_grant/coverage. 348 / 438 LOC (79.45%) covered.
```
