### PR TITLE
Add testing for Ruby 3.3 to CI

### DIFF
--- a/.github/workflows/ruby_ci.yml
+++ b/.github/workflows/ruby_ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [ 2.7, '3.0', '3.1', '3.2' ]
+        ruby: [ 2.7, '3.0', '3.1', '3.2', '3.3' ]
         gemfile: [ rails_5_2, rails_6_0, rails_6_1, rails_7_0, rails_main ]
         exclude:
           - ruby: '3.0'
@@ -17,6 +17,8 @@ jobs:
           - ruby: '3.1'
             gemfile: rails_5_2
           - ruby: '3.2'
+            gemfile: rails_5_2
+          - ruby: '3.3'
             gemfile: rails_5_2
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile


### PR DESCRIPTION
Testing against Ruby 3.3 would be required for Mastodon to be [able to use](https://github.com/mastodon/mastodon/issues/23408) this gem for its device code authorization grant flows.