### PR TITLE
Fix: Test failures due to Minitest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,5 @@ gemspec
 
 gem 'rails', '~> 7.0.0'
 gem 'sprockets-rails', '~> 3.0'
+
+gem 'minitest', '~> 5.25.2', group: %i[development test]

--- a/test/lib/oauth/device_authorization_request_test.rb
+++ b/test/lib/oauth/device_authorization_request_test.rb
@@ -13,7 +13,7 @@ module Doorkeeper
             redirect_uri: 'https://example.com/application/redirect'
           )
 
-          @server = MiniTest::Mock.new
+          @server = Minitest::Mock.new
           @server.expect(:default_scopes, 'public')
 
           @request = DeviceAuthorizationRequest.new(

--- a/test/lib/oauth/device_code_request_test.rb
+++ b/test/lib/oauth/device_code_request_test.rb
@@ -13,7 +13,7 @@ module Doorkeeper
             redirect_uri: 'https://example.com/application/redirect'
           )
 
-          @server = MiniTest::Mock.new
+          @server = Minitest::Mock.new
           @server.expect(:access_token_expires_in, 2.days)
           @server.expect(
             :option_defined?,


### PR DESCRIPTION
In Minitest 5.0.0, the main module was renamed from `MiniTest` to `Minitest`, however a compatibility layer existed. In 5.10.0, the `MiniTest` namespace was deprecated, and in 5.19 the compatibility layer was moved behind an environment variable (so technically Minitest had a breaking change in a minor version)

That lead to this error: https://github.com/minitest/minitest/tree/master?tab=readme-ov-file#label-Why+am+I+seeing+uninitialized+constant+MiniTest-3A-3ATest+-28NameError-29-3F

This fixes #17, with thanks to @mjankowski for notice the issue.