### PR TITLE
Enforce validation of requested scopes against server and application scopes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,8 @@ gemspec
 gem 'rails', '~> 7.0.0'
 gem 'sprockets-rails', '~> 3.0'
 
-gem 'minitest', '~> 5.25.2', group: %i[development test]
+group :development, :test do
+  gem 'minitest', '~> 5.25.2'
+  # Interactive Debugging tools
+  gem 'debug', '~> 1.8'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,5 @@ gemspec
 
 gem 'rails', '~> 7.0.0'
 gem 'sprockets-rails', '~> 3.0'
+
+gem 'minitest', '~> 5.25.2', group: %i[development test]

--- a/lib/doorkeeper/device_authorization_grant/oauth/device_authorization_request.rb
+++ b/lib/doorkeeper/device_authorization_grant/oauth/device_authorization_request.rb
@@ -13,6 +13,7 @@ module Doorkeeper
         attr_accessor :host_name
 
         validate :client, error: :invalid_client
+        validate :scopes, error: Doorkeeper::Errors::InvalidScope
 
         # @param server
         # @param client
@@ -58,6 +59,15 @@ module Doorkeeper
         # @return [Boolean]
         def validate_client
           client.present?
+        end
+
+        def validate_scopes
+          Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(
+            scope_str: scopes.to_s,
+            server_scopes: @server.scopes,
+            app_scopes: @client.scopes,
+            grant_type: Doorkeeper::DeviceAuthorizationGrant::OAuth::DEVICE_CODE
+          )
         end
 
         # @return [Doorkeeper::DeviceAuthorizationGrant::DeviceGrant]

--- a/lib/doorkeeper/device_authorization_grant/oauth/device_authorization_request.rb
+++ b/lib/doorkeeper/device_authorization_grant/oauth/device_authorization_request.rb
@@ -61,11 +61,12 @@ module Doorkeeper
           client.present?
         end
 
+        # @return [Boolean]
         def validate_scopes
           Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(
             scope_str: scopes.to_s,
-            server_scopes: @server.scopes,
-            app_scopes: @client.scopes,
+            server_scopes: server.scopes,
+            app_scopes: client.scopes,
             grant_type: Doorkeeper::DeviceAuthorizationGrant::OAuth::DEVICE_CODE
           )
         end

--- a/test/lib/oauth/device_authorization_request_test.rb
+++ b/test/lib/oauth/device_authorization_request_test.rb
@@ -13,7 +13,7 @@ module Doorkeeper
             redirect_uri: 'https://example.com/application/redirect'
           )
 
-          @server = MiniTest::Mock.new
+          @server = Minitest::Mock.new
           @server.expect(:default_scopes, 'public')
 
           @request = DeviceAuthorizationRequest.new(

--- a/test/lib/oauth/device_code_request_test.rb
+++ b/test/lib/oauth/device_code_request_test.rb
@@ -13,7 +13,7 @@ module Doorkeeper
             redirect_uri: 'https://example.com/application/redirect'
           )
 
-          @server = MiniTest::Mock.new
+          @server = Minitest::Mock.new
           @server.expect(:access_token_expires_in, 2.days)
           @server.expect(
             :option_defined?,

--- a/test/lib/oauth/device_code_request_test.rb
+++ b/test/lib/oauth/device_code_request_test.rb
@@ -7,22 +7,39 @@ module Doorkeeper
   module DeviceAuthorizationGrant
     module OAuth
       class DeviceCodeRequestTest < ActiveSupport::TestCase
+        class MockServer
+          def default_scopes
+            Doorkeeper.config.default_scopes
+          end
+
+          def optional_scopes
+            Doorkeeper.config.optional_scopes
+          end
+
+          def scopes
+            Doorkeeper.config.default_scopes + Doorkeeper.config.optional_scopes
+          end
+
+          def access_token_expires_in
+            2.days
+          end
+
+          def refresh_token_enabled?
+            false
+          end
+
+          def option_defined?(option)
+            false if option == :custom_access_token_expires_in
+          end
+        end
+
         setup do
           @application = Doorkeeper::Application.create!(
             name: 'Application',
             redirect_uri: 'https://example.com/application/redirect'
           )
 
-          @server = Minitest::Mock.new
-          @server.expect(:access_token_expires_in, 2.days)
-          @server.expect(
-            :option_defined?,
-            false,
-            [:custom_access_token_expires_in]
-          )
-          def @server.refresh_token_enabled?
-            false
-          end
+          @server = MockServer.new
 
           @expired_device_grant = DeviceGrant.create!(
             created_at: 61.seconds.ago,


### PR DESCRIPTION
This builds on #19 

I did have some trouble getting this working due to the kind of brittle way mocking of the Doorkeeper Server class was implemented in the tests, which lead me to create these MockServer classes instead, as Minitest::Mock failed due to doorkeeper internals calling methods multiple times. As we want to test this gem, and not doorkeeper, it makes sense to not use Minitest::Mock here, in my opinion.

I believe this fixes #9, however, I'm doing the validation of the requested scopes when creating the authorization request, not as part of the model's validations.