### PR TITLE
Update CI for ruby 3.3 & 3.4 compatibility

### DIFF
--- a/.github/workflows/ruby_ci.yml
+++ b/.github/workflows/ruby_ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [ 2.7, '3.0', '3.1', '3.2' ]
+        ruby: [ 2.7, '3.0', '3.1', '3.2', '3.3', '3.4' ]
         gemfile: [ rails_5_2, rails_6_0, rails_6_1, rails_7_0, rails_main ]
         exclude:
           - ruby: '3.0'
@@ -18,6 +18,14 @@ jobs:
             gemfile: rails_5_2
           - ruby: '3.2'
             gemfile: rails_5_2
+          - ruby: '3.3'
+            gemfile: rails_5_2
+          - ruby: '3.3'
+            gemfile: rails_6_0
+          - ruby: '3.4'
+            gemfile: rails_5_2
+          - ruby: '3.4'
+            gemfile: rails_6_0
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:


### PR DESCRIPTION
Rails exclusions based on https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html